### PR TITLE
Avoid using deprecated GROMACS option in test

### DIFF
--- a/tests/test_run_simulations.sh
+++ b/tests/test_run_simulations.sh
@@ -17,18 +17,25 @@ RUN_SCRIPT=scripts/run_simulations.sh
 GMX=gmx
 which $GMX &> /dev/null || fail "Executable $GMX not found."
 
+# Do some changes to input files to ensure fast runs
+for file in input/*.mdp; do cp $file $file.bk; done
+perl -pi -e 's/^nsteps *=\K.+/ 2/' input/*.mdp
+
 TEST_SYSTEM=1HPX
 WORKDIR=systems/$TEST_SYSTEM
 TOPDIR=$WORKDIR
 CRD=$WORKDIR/system.gro
 # Check that typical usage runs without errors, using very small simulations to be fast
-bash $RUN_SCRIPT -d $WORKDIR/sys2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1 -nsteps 2" -s 2 -p min || fail "Error in simulation."
-bash $RUN_SCRIPT -d $WORKDIR/sys2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1 -nsteps 2" -s 2 -p eqNVT || fail "Error in simulation."
-bash $RUN_SCRIPT -d $WORKDIR/sys2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1 -nsteps 2" -s 2 -p eqNPT || fail "Error in simulation."
-bash $RUN_SCRIPT -d $WORKDIR/sys2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1 -nsteps 2" -s 2 -p prod || fail "Error in simulation."
+bash $RUN_SCRIPT -d $WORKDIR/sys2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 2 -p min || fail "Error in simulation."
+bash $RUN_SCRIPT -d $WORKDIR/sys2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 2 -p eqNVT || fail "Error in simulation."
+bash $RUN_SCRIPT -d $WORKDIR/sys2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 2 -p eqNPT || fail "Error in simulation."
+bash $RUN_SCRIPT -d $WORKDIR/sys2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 2 -p prod || fail "Error in simulation."
 # Run the other systems in one go
-bash $RUN_SCRIPT -d $WORKDIR/sys1 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1 -nsteps 2" -s 1 -p "min eqNVT eqNPT prod" || fail "Error in simulation."
-bash $RUN_SCRIPT -d $WORKDIR/sys3 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1 -nsteps 2" -s 3 -p "min eqNVT eqNPT prod" || fail "Error in simulation."
+bash $RUN_SCRIPT -d $WORKDIR/sys1 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 1 -p "min eqNVT eqNPT prod" || fail "Error in simulation."
+bash $RUN_SCRIPT -d $WORKDIR/sys3 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 3 -p "min eqNVT eqNPT prod" || fail "Error in simulation."
+
+# Restore the original mdp files
+for file in input/*.mdp; do mv $file.bk $file; done
 
 # If we reached here, all commands passed without error!
 echo "SUCCESS: All simulations ran without error."


### PR DESCRIPTION
The test was using the command line flag `-nsteps 2` to reduce the
number of steps `gmx mdrun` simulates. This allows all simulations to
run in the matter of seconds. This command line flag is, however,
deprecated.

This commit changes the test to actually modify the mdp files before
running the test. This is less elegant, but has two advantages:

1. It doesn't use a deprecated interface
2. It is more versatile, we will be able to change other settings in
   the same manner.