### PR TITLE
Add script to create starting structures for NES phase

### DIFF
--- a/scripts/prepare_nes_structures.sh
+++ b/scripts/prepare_nes_structures.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+function usage()
+{
+  echo "USAGE: prepare_nes_structures [-h] -d dir -x gmx -n num"
+}
+
+function help()
+{
+  echo "Prepare structures for NES simulations"
+  echo
+  usage
+  echo "Options:"
+  echo -e "-h\tPrint this help and exit"
+  echo -e "-d dir\tThe base working directory of the stage"
+  echo -e "\tThis directory is expected to have a subdirectory `prod`"
+  echo -e "\twith the results of the production simulation of that stage"
+  echo -e "-x gmx\tThe GROMACS executable to use"
+  echo -e "-n num\tThe number of structures to prepare"
+  echo
+}
+
+function fail()
+{
+  echo -e "ERROR: $1"
+  exit 1
+}
+
+# Get the options
+while getopts "hd:x:n:" option; do
+  case $option in
+    d) BASEDIR="${OPTARG}";;
+    x) GMX="${OPTARG}";;
+    n) NUM_STRUCTURES="${OPTARG}";;
+    h) help; exit 0;;
+    *) usage; exit 1;;
+  esac
+done
+
+# Check presence of positional arguments
+if [ -z "$BASEDIR" ] || [ -z "$GMX" ] || [ -z "$NUM_STRUCTURES" ]; then
+  usage
+  exit 1
+fi
+
+# Check option values
+[ -d "$BASEDIR" ] || fail "Directory $BASEDIR does not exist."
+which $GMX &> /dev/null || fail "Executable $GMX not found."
+[ $NUM_STRUCTURES -gt 0 ] &> /dev/null || fail "Number of structures $NUM_STRUCTURES is not a valid number."
+
+# Make sure all relevant files and folders are present
+WORKDIR=$BASEDIR/prod
+[ -d $WORKDIR ] || fail "Production simulation folder $WORKDIR not found."
+TRJ=$WORKDIR/traj.trr
+[ -e $TRJ ] || fail "Production trajectory $TRJ not found."
+MDP=$WORKDIR/mdout.mdp
+[ -e $MDP ] || fail "Production mdp file $MDP not found."
+
+# Find the frequency at which we want to extract structures, do some sanity checks
+WRITE_FREQUENCY=$(grep "nstxout " $MDP | awk '{print $NF;}')
+NUM_STEPS=$(grep "nsteps " $MDP | awk '{print $NF;}')
+NUM_FRAMES=$(($NUM_STEPS/$WRITE_FREQUENCY))
+echo "INFO: Production simulation with nsteps = $NUM_STEPS, nstxout = $WRITE_FREQUENCY, generated $NUM_FRAMES frames."
+
+[ $NUM_FRAMES -ge $NUM_STRUCTURES ] || \
+  fail "Production simulation generated only $NUM_FRAMES frame, cannot create $NUM_STRUCTURES structures."
+[ $(($NUM_FRAMES%$NUM_STRUCTURES)) -eq 0 ] || \
+  echo "WARNING: Production simulation generated $NUM_FRAMES, which is not a multiple of the number of structures ($NUM_STRUCTURES)."
+
+# Go to simulation directory
+STARTDIR=$PWD
+cd $WORKDIR || fail "Could not access directory $WORKDIR."
+mkdir -p frames
+
+# Extract frames
+echo "System" | $GMX trjconv -f traj.trr -o frames/frame.gro -sep -skip $(($NUM_FRAMES/$NUM_STRUCTURES)) -ur compact -pbc mol || \
+  fail "trjconv command failed:\n\t$GMX trjconv -f $TRJ -o frame.gro -sep -skip $(($NUM_FRAMES/$NUM_STRUCTURES)) -ur compact -pbc mol"
+# Ignore the zero frame
+rm -f frames/frame0.gro
+
+# Return to initial directory & exit
+cd $STARTDIR || fail "Could not access directory $STARTDIR."
+FRAME_NUMBERS=$([ $NUM_STRUCTURES -eq 1 ] && echo 1 || echo "{1-$NUM_STRUCTURES}")
+echo "Successfully created $NUM_STRUCTURES frames, $WORKDIR/frames/frame$FRAME_NUMBERS.gro"

--- a/scripts/run_simulations.sh
+++ b/scripts/run_simulations.sh
@@ -12,7 +12,7 @@ function help()
   usage
   echo "Options:"
   echo -e "-h\tPrint this help and exit"
-  echo -e "-d dir\tThe base working directory for the system"
+  echo -e "-d dir\tThe base working directory for the stage"
   echo -e "-t top\tThe topology directory including topology files"
   echo -e "-c crd\tThe input coordinates, for minimization only"
   echo -e "-x gmx\tThe GROMACS executable to use"

--- a/tests/test_run_simulations.sh
+++ b/tests/test_run_simulations.sh
@@ -10,8 +10,10 @@ function fail()
 [ -e tests/$(basename $0) ] || fail "Expected to be in the root repository."
 
 RUN_SCRIPT=scripts/run_simulations.sh
+STRUCTURES_SCRIPT=scripts/prepare_nes_structures.sh
 # Check that we can find the script we want to test
 [ -e $RUN_SCRIPT ] || fail "Can't find script $RUN_SCRIPT."
+[ -e $STRUCTURES_SCRIPT ] || fail "Can't find script $STRUCTURES_SCRIPT."
 
 # Check that GROMACS is available as `gmx`
 GMX=gmx
@@ -19,20 +21,25 @@ which $GMX &> /dev/null || fail "Executable $GMX not found."
 
 # Do some changes to input files to ensure fast runs
 for file in input/*.mdp; do cp $file $file.bk; done
-perl -pi -e 's/^nsteps *=\K.+/ 2/' input/*.mdp
+perl -pi -e 's/^nsteps *=\K.+/ 4/' input/*.mdp
+perl -pi -e 's/^nstxout *=\K.+/ 2/' input/*.mdp
 
 TEST_SYSTEM=1HPX
 WORKDIR=systems/$TEST_SYSTEM
 TOPDIR=$WORKDIR
 CRD=$WORKDIR/system.gro
 # Check that typical usage runs without errors, using very small simulations to be fast
-bash $RUN_SCRIPT -d $WORKDIR/sys2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 2 -p min || fail "Error in simulation."
-bash $RUN_SCRIPT -d $WORKDIR/sys2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 2 -p eqNVT || fail "Error in simulation."
-bash $RUN_SCRIPT -d $WORKDIR/sys2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 2 -p eqNPT || fail "Error in simulation."
-bash $RUN_SCRIPT -d $WORKDIR/sys2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 2 -p prod || fail "Error in simulation."
-# Run the other systems in one go
-bash $RUN_SCRIPT -d $WORKDIR/sys1 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 1 -p "min eqNVT eqNPT prod" || fail "Error in simulation."
-bash $RUN_SCRIPT -d $WORKDIR/sys3 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 3 -p "min eqNVT eqNPT prod" || fail "Error in simulation."
+bash $RUN_SCRIPT -d $WORKDIR/stage2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 2 -p min || fail "Error in simulation."
+bash $RUN_SCRIPT -d $WORKDIR/stage2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 2 -p eqNVT || fail "Error in simulation."
+bash $RUN_SCRIPT -d $WORKDIR/stage2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 2 -p eqNPT || fail "Error in simulation."
+bash $RUN_SCRIPT -d $WORKDIR/stage2 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 2 -p prod || fail "Error in simulation."
+# Run the other stages in one go
+bash $RUN_SCRIPT -d $WORKDIR/stage1 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 1 -p "min eqNVT eqNPT prod" || fail "Error in simulation."
+bash $RUN_SCRIPT -d $WORKDIR/stage3 -t $TOPDIR -c $CRD -x $GMX -o "-nt 1" -s 3 -p "min eqNVT eqNPT prod" || fail "Error in simulation."
+
+# Prepare NES structures for stages 2 and 3, using different numbers of structures
+bash $STRUCTURES_SCRIPT -d $WORKDIR/stage2 -x $GMX -n 2 || fail "Error in NES structure preparation"
+bash $STRUCTURES_SCRIPT -d $WORKDIR/stage3 -x $GMX -n 1 || fail "Error in NES structure preparation"
 
 # Restore the original mdp files
 for file in input/*.mdp; do mv $file.bk $file; done


### PR DESCRIPTION
Added a script that creates starting structures for the NES phase by
taking periodic structures from the long production simulations.

Added calls to the script in tests/test_run_simulations.sh to make
sure it runs without errors.

Fixed a few instances of using "system" instead of "stage" for
consistency.