### PR TITLE
Add NES simulations

### DIFF
--- a/input/NES.mdp
+++ b/input/NES.mdp
@@ -1,0 +1,77 @@
+; PREPROCESSING
+; Directories to include in your topology (-I/path/to/directory/)
+;include                  =
+; DFLEXIBLE for flexible waters, DPOSRES for position restraints
+;define                   = -DFLEXIBLE ;-DPOSRES
+
+; Run control
+integrator               = sd       ; Langevin dynamics
+tinit                    = 0
+dt                       = 0.002
+nsteps                   = 125000    ; 250 ps
+comm-mode                = Linear
+nstcomm                  = 500
+; Output control
+nstxout                  = 10000
+nstvout                  = 10000
+nstfout                  = 10000
+nstlog                   = 1000
+nstcalcenergy            = 1
+nstdhdl                  = 1
+nstxout-compressed       = 5000
+compressed-x-precision   = 1000
+
+; Neighborsearching and short-range nonbonded interactions
+cutoff-scheme            = verlet
+nstlist                  = 20
+ns_type                  = grid
+pbc                      = xyz
+rlist                    = 1.2
+
+; Electrostatics
+coulombtype              = PME
+rcoulomb-switch          = 0
+rcoulomb                 = 1.2
+; van der Waals
+vdwtype                  = Cutoff
+vdw-modifier             = Potential-switch
+rvdw-switch              = 0.9
+rvdw                     = 1.0
+
+; Apply long range dispersion corrections for Energy and Pressure
+DispCorr                  = EnerPres
+; Spacing for the PME/PPPM FFT grid
+fourierspacing           = 0.10
+
+; EWALD/PME/PPPM parameters
+pme_order                = 6
+ewald_rtol               = 1e-06
+epsilon_surface          = 0
+
+; Temperature coupling
+; tcoupl is implicitly handled by the sd integrator
+tcoupl                   = no
+tc_grps                  = system
+tau_t                    = 1.0
+ref_t                    = 298.15
+
+; Pressure coupling is on for NPT
+pcoupl                   = Parrinello-Rahman
+pcoupltype               = isotropic
+tau_p                    = 1.0
+compressibility          = 4.5e-05
+ref_p                    = 1.01325
+
+; Do not generate velocities
+gen-vel                  = no
+;gen-temp                 = 298.15
+;gen-seed                 = -1
+; options for bonds
+constraints              = h-bonds
+; Type of constraint algorithm
+constraint-algorithm     = Lincs
+; Constrain the starting configuration
+; since we are continuing from NVT
+continuation             = yes
+; Highest order in the expansion of the constraint coupling matrix
+lincs-order              = 12

--- a/input/stage2NES1.mdp
+++ b/input/stage2NES1.mdp
@@ -1,0 +1,13 @@
+; Free energy control stuff
+free_energy              = yes
+init_lambda              = 0
+delta_lambda             = 0.000008  ;1/nsteps
+; Options for the decoupling
+sc-alpha                 = 0
+sc-coul                  = no
+sc-power                 = 1
+sc-sigma                 = 0.3
+couple-moltype           = MOL
+couple-intramol          = no
+couple-lambda0           = vdw-q ;(state A)
+couple-lambda1           = vdw   ;(state B)

--- a/input/stage2NES2.mdp
+++ b/input/stage2NES2.mdp
@@ -1,0 +1,13 @@
+; Free energy control stuff
+free_energy              = yes
+init_lambda              = 0
+delta_lambda             = 0.000008  ;1/nsteps
+; Options for the decoupling
+sc-alpha                 = 0.5
+sc-coul                  = no
+sc-power                 = 1
+sc-sigma                 = 0.3
+couple-moltype           = MOL
+couple-intramol          = no
+couple-lambda0           = vdw  ;(state A)
+couple-lambda1           = none ;(state B)

--- a/input/stage3NES1.mdp
+++ b/input/stage3NES1.mdp
@@ -1,0 +1,13 @@
+; Free energy control stuff
+free_energy              = yes
+init_lambda              = 1
+delta_lambda             = -0.000008 ;1/nsteps
+; Options for the decoupling
+sc-alpha                 = 0.5
+sc-coul                  = no
+sc-power                 = 1
+sc-sigma                 = 0.3
+couple-moltype           = MOL
+couple-intramol          = no
+couple-lambda0           = vdw  ;(state A)
+couple-lambda1           = none ;(state B)

--- a/input/stage3NES2.mdp
+++ b/input/stage3NES2.mdp
@@ -1,0 +1,13 @@
+; Free energy control stuff
+free_energy              = yes
+init_lambda              = 1
+delta_lambda             = -0.000008 ;1/nsteps
+; Options for the decoupling
+sc-alpha                 = 0
+sc-coul                  = no
+sc-power                 = 1
+sc-sigma                 = 0.3
+couple-moltype           = MOL
+couple-intramol          = no
+couple-lambda0           = vdw-q ;(state A)
+couple-lambda1           = vdw   ;(state B)

--- a/scripts/prepare_nes_structures.sh
+++ b/scripts/prepare_nes_structures.sh
@@ -2,7 +2,7 @@
 
 function usage()
 {
-  echo "USAGE: prepare_nes_structures [-h] -d dir -x gmx -n num"
+  echo "USAGE: $(basename $0) [-h] -d dir -x gmx -n num"
 }
 
 function help()
@@ -13,7 +13,7 @@ function help()
   echo "Options:"
   echo -e "-h\tPrint this help and exit"
   echo -e "-d dir\tThe base working directory of the stage"
-  echo -e "\tThis directory is expected to have a subdirectory `prod`"
+  echo -e "\tThis directory is expected to have a subdirectory prod/"
   echo -e "\twith the results of the production simulation of that stage"
   echo -e "-x gmx\tThe GROMACS executable to use"
   echo -e "-n num\tThe number of structures to prepare"

--- a/scripts/run_simulations.sh
+++ b/scripts/run_simulations.sh
@@ -2,7 +2,7 @@
 
 function usage()
 {
-  echo "USAGE: run_water_nes [-h] -d dir -t dir [-c crd] -x gmx [-o opts] -s N -p {min,eqNVT,eqNPT,prod}"
+  echo "USAGE: $(basename $0) [-h] -d dir -t dir [-c crd] -x gmx [-o opts] -s N -p {min,eqNVT,eqNPT,prod,NES} [-n N]"
 }
 
 function help()
@@ -14,16 +14,20 @@ function help()
   echo -e "-h\tPrint this help and exit"
   echo -e "-d dir\tThe base working directory for the stage"
   echo -e "-t top\tThe topology directory including topology files"
-  echo -e "-c crd\tThe input coordinates, for minimization only"
+  echo -e "-c crd\tThe input coordinates"
+  echo -e "\tMandatory for the minimization phase, ignored otherwise"
   echo -e "-x gmx\tThe GROMACS executable to use"
   echo -e "-o opts\tThe run options, e.g. \"-nt 16 -ntomp 4\", optional"
   echo -e "-s N\tThe stage to run, one of:"
   echo -e "\t1: Stage with fully interacting, non-restrained water"
   echo -e "\t2: Stage with fully interacting, restrained water"
   echo -e "\t3: Stage with non-interacting, restrained water"
-  echo -e "-p {min,eqNVT,eqNPT,prod}"
-  echo -e "\tThe simulation phase to run, one or more of: min, eqNVT, eqNPT, prod"
-  echo -e "\tSeparate different phases by spaces, e.g. -p \"min eqNVT eqNPT\"".
+  echo -e "-p {min,eqNVT,eqNPT,prod,NES}"
+  echo -e "\tThe simulation phase to run, one or more of: min, eqNVT, eqNPT, prod, NES"
+  echo -e "\tSeparate different phases by spaces, e.g. -p \"min eqNVT eqNPT\""
+  echo -e "\tNote: The NES phase is only available for stages 2 and 3"
+  echo -e "-n N\tThe run number for the NES phase"
+  echo -e "\tMandatory for the NES phase, ignored otherwise"
   echo
 }
 
@@ -34,7 +38,7 @@ function fail()
 }
 
 # Get the options
-while getopts "d:t:c:x:o:s:p:h" option; do
+while getopts "d:t:c:x:o:s:p:n:h" option; do
   case $option in
     d) BASEDIR="${OPTARG}";;
     t) TOPDIR="${OPTARG}";;
@@ -43,13 +47,14 @@ while getopts "d:t:c:x:o:s:p:h" option; do
     o) RUN_PARAMS="${OPTARG}";;
     s) STAGE="${OPTARG}";;
     p) PHASES="${OPTARG}";;
+    n) RUN_NUMBER="${OPTARG}";;
     h) help; exit 0;;
     *) usage; exit 1;;
   esac
 done
 
 IMPLEMENTED_STAGES="1 2 3"
-IMPLEMENTED_PHASES="min eqNVT eqNPT prod"
+IMPLEMENTED_PHASES="min eqNVT eqNPT prod NES"
 
 # Check presence of positional arguments
 if [ -z "$BASEDIR" ] || [ -z "$TOPDIR" ] || [ -z "$GMX" ] || [ -z "$STAGE" ] || [ -z "$PHASES" ]; then
@@ -76,6 +81,14 @@ for phase in $PHASES; do
   if [ "$phase" == "min" ]; then
     if [ -z "$CRD" ] || [ ! -e "$CRD" ]; then
       fail "Minimization phase requires a valid coordinate input file."
+    fi
+  fi
+  if [ "$phase" == "NES" ]; then
+    if [ -z "$RUN_NUMBER" ] || ! [ $RUN_NUMBER -ge 1 ] &> /dev/null; then
+      fail "NES phase requires a run number (-n) greater or equal 1"
+    fi
+    if [ $STAGE -ne 2 ] && [ $STAGE -ne 3 ]; then
+      fail "NES phase is only implemented for stages 2 and 3"
     fi
   fi
 done
@@ -127,7 +140,11 @@ for phase in $PHASES; do
   echo "Running phase $phase ..."
 
   # Create work directory if it doesn't exist
-  WORKDIR=$BASEDIR/$phase
+  if [ "$phase" != "NES" ]; then
+    WORKDIR=$BASEDIR/$phase
+  else
+    WORKDIR=$BASEDIR/$phase/run$RUN_NUMBER
+  fi
   mkdir -p $WORKDIR
   
   # Pick input coordinates for phase
@@ -136,6 +153,7 @@ for phase in $PHASES; do
     "eqNVT") GRO=$BASEDIR/min/confout.gro;;
     "eqNPT") GRO=$BASEDIR/eqNVT/confout.gro;;
     "prod") GRO=$BASEDIR/eqNPT/confout.gro;;
+    "NES") GRO=$BASEDIR/prod/frames/frame$RUN_NUMBER.gro;;
     *) echo "Unknown phase";;
   esac
   [ -e $GRO ] || fail "Phase $phase cannot be run because coordinate file $GRO is missing."
@@ -143,19 +161,39 @@ for phase in $PHASES; do
   # Create input file for phase & stage
   MDP=$WORKDIR/input.mdp
   cp $INPUTDIR/$phase.mdp $MDP || fail "Error creating input file"
-  cat $INPUTDIR/stage$STAGE.mdp >> $MDP || fail "Error creating input file"
+  if [ "$phase" != "NES" ]; then
+    cat $INPUTDIR/stage$STAGE.mdp >> $MDP || fail "Error creating input file"
+  else
+    MDP2=$WORKDIR/input2.mdp
+    cp $MDP $MDP2
+    cat $INPUTDIR/stage${STAGE}NES1.mdp >> $MDP || fail "Error creating input file"
+    cat $INPUTDIR/stage${STAGE}NES2.mdp >> $MDP2 || fail "Error creating input file"
+  fi
 
   # Create topology file for phase & stage
   TOP=$WORKDIR/topology.top
   cp $TOPDIR/system.top $TOP || fail "Error creating topology file"
-  if [ $STAGE -eq 3 ]; then
+  if [ $STAGE -eq 3 ] || [ "$phase" == "NES" ]; then
+    # Stage 3 is running with full restraints, but doesn't need to calculate dH/dL
+    # When using NES phase, also stage 2 doesn't need to calculate dH/dL for the restraint
+    # If using the lambda dependent restraint, the NES simulations would turn on / off the restraint
     RESTRAINT_FILE=waterRestraintLambdaIndependent.top
   else
+    # Stage 1 is running at lambda point that has no restraint
+    # Stage 2 is running at lambda point with restraints, calculating dH/dL
     RESTRAINT_FILE=waterRestraintLambdaDependent.top
   fi
   echo >> $TOP
   cat $TOPDIR/$RESTRAINT_FILE >> $TOP || fail "Error creating topology file"
   
-  run_simulation $WORKDIR $MDP $GRO $TOP
+  if [ "$phase" != "NES" ]; then
+    run_simulation $WORKDIR $MDP $GRO $TOP
+  else
+    # For NES, we run two simulations, were the second starts from
+    # the final configuration of the first
+    mkdir -p $WORKDIR/1 $WORKDIR/2
+    run_simulation $WORKDIR/1 $MDP $GRO $TOP
+    run_simulation $WORKDIR/2 $MDP2 $WORKDIR/1/confout.gro $TOP
+  fi
 
 done


### PR DESCRIPTION
This extends the run_simulation script to include the NES simulations,
and adds the required input files.

Additionally, this

* Updates the README to describe the new phase
* Updates the README to include the NES preparation script
* Fixes some minor errors and typos in the README
* Adds tests for the NES phase