### PR TITLE
Add simple HPC3 scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ can be used.
   
 ### Stages
 * **Stage 1**: This simulates the protein complex with an
-  unrestained, fully interacting water molecule.  Simulations include
+  unrestrained, fully interacting water molecule.  Simulations include
   minimization, equilibration in NVT and NPT, production simulation in
   NPT. During the production run, the free energy with respect to the
   water restraint (which is turned off) is calculated.
@@ -113,7 +113,7 @@ $\lambda$-independent position restraints for the water, named
 
 The coordinate file (`-c`) needs to contain starting coordinates for
 the system matching with the topology found in the topology directory.
-This is only needed for the mimization phase.
+This is only needed for the minimization phase.
 
 The GROMACS executable to use (`-x`) can either be a path to an
 executable, or simply `gmx` if it is in the path.
@@ -168,7 +168,7 @@ The directory (`-d`) is the base directory of the stage in which all
 simulation input and output was written, and should be the same
 directory that was used for the `-d` flag of the `run_simulations.sh`
 script. Specifically, the script is looking for the mdp file and the
-trajectory file in the `prod/` subfolder.
+trajectory file in the `prod/` folder under this base directory.
 
 The GROMACS executable to use (`-x`) can either be a path to an
 executable, or simply `gmx` if it is in the path.
@@ -245,7 +245,7 @@ settings of the parameter file. These are stored in
 `input/stage{1,2,3}.mdp`. Any changes to the free energy settings
 defining the different phases can be done in these files.
 
-For the NES phase, the free energy settings are different than for the
+For the NES phase, the free energy settings are different from the
 other stages, and there are two independent simulations (coupling or
 decoupling the vdW and the Coulomb interactions separately). As a
 result, there are two additional parameter files for stages 2 and 3,
@@ -278,4 +278,10 @@ test is invoked by calling `bash tests/test_run_simulations.sh` from
 the root of the repository. The test script expects `gmx` to be in the
 path.
 
-A Github action runs this test on every push and every PR to `main`.
+A GitHub action runs this test on every push and every PR to `main`.
+
+## HPC3 files
+The scripts located at `hpc3/` are example files on how to use the scripts
+in this repository on UC Irvine's HPC3 cluster. These files are mostly
+stored to improve reproducibility within the Mobley Lab, but might also be
+useful as templates to others.

--- a/hpc3/equilibrium.sh
+++ b/hpc3/equilibrium.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#SBATCH --account=DMOBLEY_LAB
+#SBATCH --partition=standard
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=16
+#SBATCH --time=2-00:00:00
+
+# This script expects the following variables to be passed in via Slurm's --export flag:
+# RUN_SCRIPT
+# SYSTEM_DIR
+# STAGE
+
+# The source command can be replaced by loading a module (if the GROMACS version you
+# want to use is available) or by a pointer to any other GROMACS installation.
+# The next line is telling shellcheck not to worry about the sourced file.
+# shellcheck source=/dev/null
+source ~/bin/gmx2022.1/bin/GMXRC
+
+# Run equilibrium simulations (minimization, equilibration, production)
+bash "$RUN_SCRIPT" -d "$SYSTEM_DIR"/stage"$STAGE" -t "$SYSTEM_DIR" \
+  -c "$SYSTEM_DIR"/system.gro -x gmx -o "-ntmpi $SLURM_CPUS_PER_TASK" \
+  -s "$STAGE" -p "min eqNVT eqNPT prod" || exit 1
+
+# For stages 2 and 3, prepare the structures for NES simulations after completion
+# of the production run. This allows to start the NES simulations as a dependency.
+if [ "$STAGE" -eq 2 ] || [ "$STAGE" -eq 3 ]; then
+  bash "$STRUCTURES_SCRIPT" -d "$SYSTEM_DIR"/stage"$STAGE" -x gmx -n "$NUM_NES"
+fi

--- a/hpc3/nes.sh
+++ b/hpc3/nes.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH --account=DMOBLEY_LAB
+#SBATCH --partition=standard
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=1
+#SBATCH --time=1-00:00:00
+
+# This script expects the following variables to be passed in via Slurm's --export flag:
+# RUN_SCRIPT
+# SYSTEM_DIR
+# STAGE
+# STRUCTURES_SCRIPT
+# NUM_NES
+
+# The source command can be replaced by loading a module (if the GROMACS version you
+# want to use is available) or by a pointer to any other GROAMCS installation.
+# The next line is telling shellcheck not to worry about the sourced file.
+# shellcheck source=/dev/null
+source ~/bin/gmx2022.1/bin/GMXRC
+
+# Run NES simulation. The simulation number is defined by the Slurm array task ID.
+bash "$RUN_SCRIPT" -d "$SYSTEM_DIR"/stage"$STAGE" -t "$SYSTEM_DIR" -x gmx \
+  -o "-ntmpi $SLURM_CPUS_PER_TASK" -s "$STAGE" -p NES -n "$SLURM_ARRAY_TASK_ID"

--- a/hpc3/run-stages-123-all-phases.sh
+++ b/hpc3/run-stages-123-all-phases.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# This script accepts system names as input, where the system needs to have a folder
+# in the systems/ folder containing starting configurations and topology files
+# Example call:
+# $ hpc3/run-stages-123-all-phases.sh 1AZ8 1C5T
+
+# Helper function to exit script in case of error
+function fail() {
+  echo -e "ERROR: $1"
+  exit 1
+}
+
+# Define variables to point where we expect the different scripts to be
+# Note that this expects this script to be run from the repo root directory
+RUN_SCRIPT=scripts/run_simulations.sh
+[ -e $RUN_SCRIPT ] || fail "Run script $RUN_SCRIPT not found"
+STRUCTURES_SCRIPT=scripts/prepare_nes_structures.sh
+[ -e $STRUCTURES_SCRIPT ] || fail "Structures script $STRUCTURES_SCRIPT not found"
+EQUILIBRIUM_SCRIPT=hpc3/equilibrium.sh
+[ -e $EQUILIBRIUM_SCRIPT ] || fail "Run script $EQUILIBRIUM_SCRIPT not found"
+NES_SCRIPT=hpc3/nes.sh
+[ -e $NES_SCRIPT ] || fail "Run script $NES_SCRIPT not found"
+# Define the size of the simulation swarm for NES simulations
+NUM_NES=100
+
+# Loop over provided systems
+for system in "$@"; do
+  echo "System $system"
+
+  # Check that system directory exists
+  SYSTEM_DIR=systems/$system
+  [ -d "$SYSTEM_DIR" ] || fail "Directory $SYSTEM_DIR not found"
+  mkdir -p "$SYSTEM_DIR"/slurm_output
+
+  # Loop over stages 1, 2, and 3
+  for stage in 1 2 3; do
+    # Submit equilibrium run (minimization, equilibration and production runs)
+    jobidEq=$(sbatch --parsable --job-name="$system"-stage$stage-equilibrium \
+      --error="$SYSTEM_DIR"/slurm_output/equilibrium-s$stage.err \
+      --output="$SYSTEM_DIR"/slurm_output/equilibrium-s$stage.out \
+      --export=RUN_SCRIPT=$RUN_SCRIPT,SYSTEM_DIR="$SYSTEM_DIR",STAGE=$stage,STRUCTURES_SCRIPT=$STRUCTURES_SCRIPT,NUM_NES=$NUM_NES \
+      $EQUILIBRIUM_SCRIPT)
+
+    # For stages 2 and 3, submit array of NES runs that depend on successful completion
+    # of the equilibrium run (i.e., will only run once the previous run is completed)
+    if [ $stage -eq 2 ] || [ $stage -eq 3 ]; then
+      sbatch --dependency=afterok:"$jobidEq" --job-name="$system"-stage$stage-nes \
+        --error="$SYSTEM_DIR"/slurm_output/nes-s$stage-%a.err \
+        --output="$SYSTEM_DIR"/slurm_output/nes-s$stage-%a.out \
+        --export=RUN_SCRIPT=$RUN_SCRIPT,SYSTEM_DIR="$SYSTEM_DIR",STAGE=$stage \
+        --array=1-$NUM_NES \
+        $NES_SCRIPT
+    fi
+  done
+done


### PR DESCRIPTION
This adds simple scripts for the HPC3 cluster, allowing to run all phases of
stages 1-3 for any system. The scripts use slurm commands to commit the
calculations to the queue.

This also fixes a few typos in the README.