### PR TITLE
Define FreeEnergyEstimate as dataclass

### DIFF
--- a/tests/test_endpoint_free_energy_regression.py
+++ b/tests/test_endpoint_free_energy_regression.py
@@ -24,4 +24,4 @@ def test_endpoint_free_energy_regression(data_regression):
 
     # Test return value, using a reasonable precision
     # (data_regression fixture requires dict input)
-    data_regression.check(round(free_energy_estimate, 4)._asdict())
+    data_regression.check(round(free_energy_estimate, 4).as_dict())

--- a/tests/test_endpoint_free_energy_regression/test_endpoint_free_energy_regression.yml
+++ b/tests/test_endpoint_free_energy_regression/test_endpoint_free_energy_regression.yml
@@ -1,4 +1,4 @@
-bootstrap_error: 0
+bootstrap_error: 0.0
 error: 0.2761
 units: kcal/mol
 value: 2.0978

--- a/tests/test_nes_free_energy_regression.py
+++ b/tests/test_nes_free_energy_regression.py
@@ -46,6 +46,6 @@ def test_calculate_nes_free_energy_regression(data_regression, file_regression):
 
     # Test return value, using a reasonable precision
     # (data_regression fixture requires dict input)
-    data_regression.check(round(free_energy_estimate, 4)._asdict())
+    data_regression.check(round(free_energy_estimate, 4).as_dict())
     # Test printed output
     file_regression.check(contents=test_output.getvalue())

--- a/tests/test_nes_free_energy_regression/test_calculate_nes_free_energy_regression.txt
+++ b/tests/test_nes_free_energy_regression/test_calculate_nes_free_energy_regression.txt
@@ -22,4 +22,4 @@
     Delta lambda: -0.00398
     Reading tests/nes_input_files/transition_B2A_coul_2.xvg    Reading tests/nes_input_files/transition_B2A_coul_3.xvg    Reading tests/nes_input_files/transition_B2A_coul_4.xvg    Reading tests/nes_input_files/transition_B2A_coul_5.xvg    Reading tests/nes_input_files/transition_B2A_coul_6.xvg    Reading tests/nes_input_files/transition_B2A_coul_7.xvg    Reading tests/nes_input_files/transition_B2A_coul_8.xvg    Reading tests/nes_input_files/transition_B2A_coul_9.xvg    Reading tests/nes_input_files/transition_B2A_coul_10.xvg
 
-FreeEnergyEstimate(value=10.4127, error=0.625, bootstrap_error=0, units='kcal/mol')
+FreeEnergyEstimate(value=10.4127, error=0.625, units='kcal/mol', bootstrap_error=0)

--- a/water_nes/analysis/endpoint_free_energy.py
+++ b/water_nes/analysis/endpoint_free_energy.py
@@ -63,6 +63,5 @@ def calculate_endpoint_free_energy(
     return FreeEnergyEstimate(
         value=get_unit_converter(output_units)(mbar.delta_f_).loc[0.0, 1.0].item(),
         error=get_unit_converter(output_units)(mbar.d_delta_f_).loc[0.0, 1.0].item(),
-        bootstrap_error=0,
         units=output_units,
     )

--- a/water_nes/analysis/free_energy_estimate.py
+++ b/water_nes/analysis/free_energy_estimate.py
@@ -1,20 +1,24 @@
-from typing import NamedTuple
+from dataclasses import asdict, dataclass
 
 
-class FreeEnergyEstimate(NamedTuple):
+@dataclass
+class FreeEnergyEstimate:
     r"""
     Represents a free energy estimate, including information
     on error estimates and units
     """
     value: float
     error: float
-    bootstrap_error: float
     units: str
+    bootstrap_error: float = 0.0
 
     def __round__(self, num_digits: int = 0) -> "FreeEnergyEstimate":
         return FreeEnergyEstimate(
             value=round(self.value, num_digits),
             error=round(self.error, num_digits),
-            bootstrap_error=round(self.bootstrap_error, num_digits),
             units=self.units,
+            bootstrap_error=round(self.bootstrap_error, num_digits),
         )
+
+    def as_dict(self) -> dict:
+        return asdict(self)

--- a/water_nes/analysis/nes_free_energy.py
+++ b/water_nes/analysis/nes_free_energy.py
@@ -153,8 +153,8 @@ def calculate_nes_free_energy(
     return FreeEnergyEstimate(
         value=convert_energy(estimate.dg, output_units),
         error=convert_energy(estimate.err, output_units),
+        units=output_units,
         bootstrap_error=convert_energy(estimate.err_boot, output_units)
         if bootstrapping_repeats > 0
         else 0,
-        units=output_units,
     )


### PR DESCRIPTION
Change FreeEnergyEstimate from being a subclass of NamedTuple to being
a dataclass. This allows recepients of the object to manipulate them.
Also allow bootstrap_error to be unset, since it's only used by one
functionality at the moment.